### PR TITLE
pass on error info in get_source_of_call, remove indent, and fix code_id

### DIFF
--- a/data/repos/java_example/Add.java
+++ b/data/repos/java_example/Add.java
@@ -19,9 +19,18 @@ public class Add {
         return a + b;
     }
 
+    @Deprecated
+    public static int sub(int a, int b) {
+        return a - b;
+    }
+
+
     @Test
     public void testAdd() {
         Assertions.assertEquals(30, add(10, 20));
     }
 
+    public void testSub() {
+        Assertions.assertEquals(10, sub(20, 10));
+    }
 }

--- a/frontend/java/collect_focal.py
+++ b/frontend/java/collect_focal.py
@@ -46,10 +46,15 @@ def get_focal_call(ast_util: ASTUtil, func: Node) -> Maybe[tuple[str, ASTLoc]]:
     func_calls = [ast_util.get_source_from_node(call) for call in calls]
     test_func_name = fuzzy_focal_name(ast_util.get_method_name(func).value_or(""))
     calls_before_assert = []
+    has_assert = False
     for call in reversed(func_calls):
         if "assert" in call:
+            has_assert = True
             break
         calls_before_assert.append(call)
+
+    if not has_assert:
+        return Nothing
 
     def get_loc(call: str) -> tuple[str, ASTLoc]:
         idx = func_calls.index(call)

--- a/frontend/parser/ast_util.py
+++ b/frontend/parser/ast_util.py
@@ -17,15 +17,16 @@ class ASTUtil:
         return parser.parse(bytes(self.src, "utf8"))
 
     def get_source_from_node(self, node: Node) -> str:
-        start = node.start_byte
-        end = node.end_byte
-
-        if node.type == "method_declaration":
-            # move the start byte to the beginning of the line
-            while start > 0 and self.src[start - 1] != "\n":
-                start -= 1
-            return remove_leading_spaces(self.src[start:end])
-        return self.src[start:end]
+        match node.type:
+            case "method_declaration":
+                start = node.start_point[0]
+                end = node.end_point[0]
+                src = "\n".join(self.src.splitlines()[start:end])
+                return remove_leading_spaces(src)
+            case _:
+                start = node.start_byte
+                end = node.end_byte
+                return self.src[start:end]
 
     def get_method_name(self, method_node: Node) -> Maybe[str]:
         if method_node.type != "method_declaration":

--- a/frontend/parser/ast_util.py
+++ b/frontend/parser/ast_util.py
@@ -21,8 +21,9 @@ class ASTUtil:
             case "method_declaration":
                 start = node.start_point[0]
                 end = node.end_point[0]
-                src = "\n".join(self.src.splitlines()[start:end])
-                return remove_leading_spaces(src)
+                src_lines = self.src.splitlines()[start : end + 1]
+                src_lines = remove_leading_spaces(src_lines)
+                return "\n".join(src_lines)
             case _:
                 start = node.start_byte
                 end = node.end_byte
@@ -62,8 +63,7 @@ class ASTUtil:
         return nodes
 
 
-def remove_leading_spaces(code: str) -> str:
+def remove_leading_spaces(lines: list[str]) -> list[str]:
     """remove leading spaces from each line"""
-    lines = code.split("\n")
     space_idx = len(lines[0]) - len(lines[0].lstrip())
-    return "\n".join(map(lambda s: s[space_idx:], lines))
+    return [s[space_idx:] for s in lines]

--- a/frontend/parser/ast_util.py
+++ b/frontend/parser/ast_util.py
@@ -20,11 +20,10 @@ class ASTUtil:
         start = node.start_byte
         end = node.end_byte
 
-        # move the start byte to the beginning of the line
-        while start > 0 and self.src[start - 1] != "\n":
-            start -= 1
-
         if node.type == "method_declaration":
+            # move the start byte to the beginning of the line
+            while start > 0 and self.src[start - 1] != "\n":
+                start -= 1
             return remove_leading_spaces(self.src[start:end])
         return self.src[start:end]
 

--- a/frontend/parser/ast_util.py
+++ b/frontend/parser/ast_util.py
@@ -19,6 +19,13 @@ class ASTUtil:
     def get_source_from_node(self, node: Node) -> str:
         start = node.start_byte
         end = node.end_byte
+
+        # move the start byte to the beginning of the line
+        while start > 0 and self.src[start - 1] != "\n":
+            start -= 1
+
+        if node.type == "method_declaration":
+            return remove_leading_spaces(self.src[start:end])
         return self.src[start:end]
 
     def get_method_name(self, method_node: Node) -> Maybe[str]:
@@ -53,3 +60,10 @@ class ASTUtil:
                 nodes.append(child)
             nodes += self.get_all_nodes_of_type(child, type, max_level=max_level - 1)
         return nodes
+
+
+def remove_leading_spaces(code: str) -> str:
+    """remove leading spaces from each line"""
+    lines = code.split("\n")
+    space_idx = len(lines[0]) - len(lines[0].lstrip())
+    return "\n".join(map(lambda s: s[space_idx:], lines))

--- a/main.py
+++ b/main.py
@@ -65,27 +65,26 @@ def focal2result(syncer: Synchronizer, repos_root, obj):
                 Position(test_lineno, test_col_offset + 1),
             ),
         )
-        test, _ = get_function_code(fake_loc, syncer.langID).value_or((None, None))
-
-    if "focal_id" in obj.keys():
-        code_id = obj["focal_id"]
-    else:
-        code_id = None
+        test, _, _ = get_function_code(fake_loc, syncer.langID).unwrap()
 
     result = {
         "test_id": obj["test_id"],
         "test": test,
-        "code_id": code_id,
     }
 
     # todo: conform return format when Failure
     match syncer.get_source_of_call(file_path, src_lineno, src_col_offset):
-        case Success((code, docstring)):
+        case Success((code, docstring, code_id)):
+            result["code_id"] = (
+                obj["focal_id"]
+                if code_id is None
+                else code_id.removeprefix(repos_root + "/")
+            )
             result["code"] = code
             result["docstring"] = docstring
         case Failure(e):
             logging.debug(e)
-            result["error"] = str(e)
+            result["error"] = e
 
     return result
 

--- a/main.py
+++ b/main.py
@@ -112,6 +112,7 @@ def process_one_focal_file(
             return n_focal, 0
 
     results = []
+    source_file = focal_file.replace("focal", "source")
     logging.debug(f"number of workdir_dict: {len(wd.keys())}")
     repos_root = os.path.abspath(repos_root)
     for workdir, workdir_objs in wd.items():
@@ -130,8 +131,9 @@ def process_one_focal_file(
             logging.debug(e)
             continue
 
-    with jsonlines.open(focal_file.replace("focal", "source"), "w") as f:
-        f.write_all(results)
+        # append to source file in loop to avoid losing data
+        with jsonlines.open(source_file, "a") as f:
+            f.write_all(results)
 
     return n_focal, sum(1 for r in results if "code" in r)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-lsp-server>=1.8.2
 jedi>=0.19.1
 returns>=0.16.1
 jsonlines>=4.0.0
-tree-sitter==0.0.6
+tree-sitter==0.20.1
 tqdm>=4.64.1
 lambdas>=0.2.0
 pygithub

--- a/scripts/decompress_repos.py
+++ b/scripts/decompress_repos.py
@@ -13,7 +13,7 @@ import tarfile
 from tqdm import tqdm
 from multiprocessing import Pool
 
-from frontend.python.utils import wrap_repo
+from frontend.util import wrap_repo
 
 
 def decompress(task):

--- a/scripts/download_repos.py
+++ b/scripts/download_repos.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from github import Github, Repository, Auth
 from typing import Tuple, Union, Optional
 
-from frontend.python.utils import log_or_skip, wrap_repo, time_limit, TimeoutException
+from frontend.util import log_or_skip, wrap_repo, time_limit, TimeoutException
 
 
 def fetch_repo(repo_id: str, timeout: int, hub: Optional[Github]):

--- a/tests/test_source_code.py
+++ b/tests/test_source_code.py
@@ -5,6 +5,8 @@ from unitsyncer.source_code import get_function_code
 from returns.maybe import Nothing, Some
 from pylspclient.lsp_structs import Location, Position, Range
 
+from unitsyncer.util import path2uri
+
 
 class TestSourceCode(unittest.TestCase):
     def test_python_get_function_code(self):
@@ -21,6 +23,31 @@ class TestSourceCode(unittest.TestCase):
         loc = Location(uri, range_)
 
         self.assertEqual(get_function_code(loc, "python"), Nothing)
+
+    def test_java_get_function_code(self):
+        uri = f"file://{os.getcwd()}/data/repos/java_example/Add.java"
+        # range_ = Range(Position(29, 36), Position(29, 37))
+        range_ = Range(Position(17, 22), Position(17, 23))
+        loc = Location(uri, range_)
+
+        add_src = "public static int add(int a, int b) {\n        return a + b;\n    }"
+
+        self.assertEqual(get_function_code(loc, "java").unwrap()[0], add_src)
+
+    def test_java_get_function_code_w_annotation(self):
+        uri = f"file://{os.getcwd()}/data/repos/java_example/Add.java"
+        range_ = Range(Position(22, 3), Position(22, 4))
+        loc = Location(uri, range_)
+        sub_src = "@Deprecated\n    public static int sub(int a, int b) {\n        return a - b;\n    }"
+
+        self.assertEqual(get_function_code(loc, "java").unwrap()[0], sub_src)
+
+    def test_real_java_method_w_annotation(self):
+        uri = f"file://{os.getcwd()}/data/java_repos/spring-cloud-spring-cloud-netflix/spring-cloud-spring-cloud-netflix-630151f/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java"
+
+        range_ = Range(Position(297, 22), Position(297, 23))
+        loc = Location(uri, range_)
+        self.assertIsNotNone(get_function_code(loc, "java").value_or(None))
 
 
 if __name__ == "__main__":

--- a/tests/test_source_code.py
+++ b/tests/test_source_code.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import logging
-from unitsyncer.source_code import python_get_function_code
+from unitsyncer.source_code import get_function_code
 from returns.maybe import Nothing, Some
 from pylspclient.lsp_structs import Location, Position, Range
 
@@ -11,16 +11,16 @@ class TestSourceCode(unittest.TestCase):
         uri = f"file://{os.getcwd()}/data/repos/py_example/src/add.py"
         range_ = Range(Position(0, 4), Position(0, 7))
         loc = Location(uri, range_)
-        add_src = "\n\ndef add(x: int, y: int) -> int:\n    return (x + y)\n"
+        add_src = "def add(x: int, y: int) -> int:\n    return x + y"
 
-        self.assertEqual(python_get_function_code(loc), Some(add_src))
+        self.assertEqual(get_function_code(loc, "python").unwrap()[0], add_src)
 
     def test_python_get_function_code_not_found(self):
         uri = f"file://{os.getcwd()}/data/repos/py_example/src/add.py"
         range_ = Range(Position(1, 4), Position(1, 7))
         loc = Location(uri, range_)
 
-        self.assertEqual(python_get_function_code(loc), Nothing)
+        self.assertEqual(get_function_code(loc, "python"), Nothing)
 
 
 if __name__ == "__main__":

--- a/tests/test_source_code.py
+++ b/tests/test_source_code.py
@@ -30,7 +30,7 @@ class TestSourceCode(unittest.TestCase):
         range_ = Range(Position(17, 22), Position(17, 23))
         loc = Location(uri, range_)
 
-        add_src = "public static int add(int a, int b) {\n        return a + b;\n    }"
+        add_src = "public static int add(int a, int b) {\n    return a + b;\n}"
 
         self.assertEqual(get_function_code(loc, "java").unwrap()[0], add_src)
 
@@ -38,7 +38,9 @@ class TestSourceCode(unittest.TestCase):
         uri = f"file://{os.getcwd()}/data/repos/java_example/Add.java"
         range_ = Range(Position(22, 3), Position(22, 4))
         loc = Location(uri, range_)
-        sub_src = "@Deprecated\n    public static int sub(int a, int b) {\n        return a - b;\n    }"
+        sub_src = (
+            "@Deprecated\npublic static int sub(int a, int b) {\n    return a - b;\n}"
+        )
 
         self.assertEqual(get_function_code(loc, "java").unwrap()[0], sub_src)
 

--- a/unitsyncer/source_code.py
+++ b/unitsyncer/source_code.py
@@ -5,6 +5,7 @@ from returns.maybe import Maybe, Nothing, Some
 from frontend.parser.ast_util import ASTUtil
 from frontend.parser.langauges import JAVA_LANGUAGE
 from tree_sitter.binding import Node
+from frontend.parser.ast_util import remove_leading_spaces
 
 
 def get_function_code(

--- a/unitsyncer/sync.py
+++ b/unitsyncer/sync.py
@@ -142,8 +142,10 @@ class Synchronizer:
             col_offset = def_location.range.start.character
             return f"Source code not found: {file_path}:{lineno}:{col_offset}"
 
-        return maybe_to_result(get_function_code(def_location, self.langID)).alt(
-            not_found_error
+        return (
+            maybe_to_result(get_function_code(def_location, self.langID))
+            .alt(not_found_error)
+            .bind(lambda t: Failure("Empty Source Code") if t[0] == "" else Success(t))
         )
 
     def stop(self):


### PR DESCRIPTION
resolve remaining issues for Java, excepting getting docstrings which is not part of Java ast